### PR TITLE
Correct method name in deprecated warning message

### DIFF
--- a/lib/activerecord-native_db_types_override/options.rb
+++ b/lib/activerecord-native_db_types_override/options.rb
@@ -7,7 +7,7 @@ module NativeDbTypesOverride
     end
 
     def configure(hash)
-      warn 'NativeDbTypesOverride.configure is deprecated! Call NativeDbTypesOverride.adapters instead of NativeDbTypesOverride.configure.'
+      warn 'NativeDbTypesOverride.configure is deprecated! Call NativeDbTypesOverride.configure_adapters instead of NativeDbTypesOverride.configure.'
       configure_adapters(hash)
     end
 


### PR DESCRIPTION
The method name should be `NativeDbTypesOverride.configure_adapters` instead of `NativeDbTypesOverride.adapters`.